### PR TITLE
[WIP] remove the need for passing names to autogold.Want

### DIFF
--- a/testdata/Test_replaceWant/issue7_reg.golden
+++ b/testdata/Test_replaceWant/issue7_reg.golden
@@ -1,0 +1,21 @@
+package foo_test
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold"
+	"github.com/stretchr/testify/suite"
+)
+
+type newUserStartTestSuite struct {
+	suite.Suite
+}
+
+func (ts *newUserStartTestSuite) TestString() {
+	want := autogold.Want("reg", "replacement")
+	want.Equal(ts.T(), `registration`)
+}
+
+func TestNewUserStartTestSuite(t *testing.T) {
+	suite.Run(t, new(newUserStartTestSuite))
+}

--- a/testdata/replace_want/issue7
+++ b/testdata/replace_want/issue7
@@ -1,0 +1,21 @@
+package foo_test
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold"
+	"github.com/stretchr/testify/suite"
+)
+
+type newUserStartTestSuite struct {
+	suite.Suite
+}
+
+func (ts *newUserStartTestSuite) TestString() {
+	want := autogold.Want("reg", nil)
+	want.Equal(ts.T(), `registration`)
+}
+
+func TestNewUserStartTestSuite(t *testing.T) {
+	suite.Run(t, new(newUserStartTestSuite))
+}

--- a/want.go
+++ b/want.go
@@ -225,7 +225,6 @@ func replaceWant(testFilePath, testName, valueName, replacement string) ([]byte,
 func findWantCallExpr(fset *token.FileSet, f *ast.File, testName, valueName string) (*ast.CallExpr, error) {
 	var (
 		err             error
-		foundTestFunc   bool
 		foundCallExpr   *ast.CallExpr
 		foundValueNames []string
 	)
@@ -234,18 +233,6 @@ func findWantCallExpr(fset *token.FileSet, f *ast.File, testName, valueName stri
 			return false
 		}
 		node := cursor.Node()
-		if !foundTestFunc {
-			if _, ok := node.(*ast.File); ok {
-				return true
-			}
-			if f, ok := node.(*ast.FuncDecl); ok {
-				if f.Name.Name == testName {
-					foundTestFunc = true
-				}
-				return true
-			}
-			return false
-		}
 		if foundCallExpr != nil {
 			return false
 		}
@@ -284,9 +271,6 @@ func findWantCallExpr(fset *token.FileSet, f *ast.File, testName, valueName stri
 	f = astutil.Apply(f, pre, nil).(*ast.File)
 	if err != nil {
 		return nil, err
-	}
-	if !foundTestFunc {
-		return nil, fmt.Errorf("%s: could not find test function: %s", fset.File(f.Pos()).Name(), testName)
 	}
 	if foundCallExpr == nil {
 		if len(foundValueNames) > 0 {

--- a/want_test.go
+++ b/want_test.go
@@ -60,7 +60,7 @@ C error
 			testName:    "TestWrongName",
 			valueName:   "WrongTestName",
 			replacement: `"replacement"`,
-			err:         `testdata/replace_want/complex: could not find test function: TestWrongName`,
+			err:         `testdata/replace_want/complex: could not find autogold.Want("WrongTestName", ...) function call (did find "Europe", "America", …)`,
 		},
 		{
 			file:        "missing",
@@ -68,6 +68,12 @@ C error
 			valueName:   "Missing",
 			replacement: `"replacement"`,
 			err:         `testdata/replace_want/missing: could not find autogold.Want("Missing", ...) function call`,
+		},
+		{
+			file:        "issue7",
+			testName:    "TestNewUserStartTestSuite",
+			valueName:   "reg",
+			replacement: `"replacement"`,
 		},
 	}
 	for _, tst := range tests {


### PR DESCRIPTION
This is a WIP PR which currently allows `autogold.Want("name", ...)` calls anywhere in the file but requires the name be unique within the scope of the entire file (rather than just in the `TestFoo` function).

I will update this PR soon to remove the name parameter entirely, see #11 