### PR TITLE
Fix -update with Colliding Subtest Names

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -14,7 +14,8 @@ jobs:
       - run: go test ./...
       # Testing with -update enabled isn't intended to update the golden files, but to help validate that there aren't
       # problems when updating is enabled, race conditions in the update process etc
-      - run: go test -race ./... -update
+      # Tests are run multiple times to help expose race-conditions as they aren't always reproduced on a single run
+      - run: go test -race -count 5 ./... -update
       - run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
       - name: Upload code coverage
         uses: codecov/codecov-action@v1

--- a/testdata/TestEqual_subtestSameNames1/first.golden
+++ b/testdata/TestEqual_subtestSameNames1/first.golden
@@ -1,0 +1,1 @@
+"TestEqual_subtestSameNames1 :: first"

--- a/testdata/TestEqual_subtestSameNames1/second.golden
+++ b/testdata/TestEqual_subtestSameNames1/second.golden
@@ -1,0 +1,1 @@
+"TestEqual_subtestSameNames1 :: second"

--- a/testdata/TestEqual_subtestSameNames1/third.golden
+++ b/testdata/TestEqual_subtestSameNames1/third.golden
@@ -1,0 +1,1 @@
+"TestEqual_subtestSameNames1 :: third"

--- a/testdata/TestEqual_subtestSameNames2/first.golden
+++ b/testdata/TestEqual_subtestSameNames2/first.golden
@@ -1,0 +1,1 @@
+"TestEqual_subtestSameNames2 :: first"

--- a/testdata/TestEqual_subtestSameNames2/second.golden
+++ b/testdata/TestEqual_subtestSameNames2/second.golden
@@ -1,0 +1,1 @@
+"TestEqual_subtestSameNames2 :: second"

--- a/testdata/TestEqual_subtestSameNames2/third.golden
+++ b/testdata/TestEqual_subtestSameNames2/third.golden
@@ -1,0 +1,1 @@
+"TestEqual_subtestSameNames2 :: third"

--- a/want_test.go
+++ b/want_test.go
@@ -108,6 +108,36 @@ func Test_getPackageNameAndPath_subdir(t *testing.T) {
 	}
 }
 
+func TestEqual_subtestSameNames1(t *testing.T) {
+	testEqualSubtestSameNames(t)
+}
+
+func TestEqual_subtestSameNames2(t *testing.T) {
+	testEqualSubtestSameNames(t)
+}
+
+func testEqualSubtestSameNames(t *testing.T) {
+	t.Parallel()
+
+	parent := t.Name()
+
+	testTable := []string{
+		"first",
+		"second",
+		"third",
+	}
+
+	for _, name := range testTable {
+		name := name
+
+		t.Run(name, func(t *testing.T) {
+			// Subtests are intentionally not run in parallel, as that makes this issue more easily reproducible
+
+			Equal(t, fmt.Sprintf("%s :: %s", parent, name))
+		})
+	}
+}
+
 func Benchmark_getPackageNameAndPath_cached(b *testing.B) {
 	// Wipe the cache, as it was populated by other tests.
 	getPackageNameAndPathCacheMu.Lock()


### PR DESCRIPTION
Golden files are moved to a temp dir when -update is enabled, which allows clean-up of golden files which are not in use. The destination path in the temp dir did not consider the adjusted output directory for subtests, which meant that subtests with the same name would be copied to the same path in the temp dir, overwriting each other. This conflict leads to a number of issues, which results in tests failing despite producing the correct output.

By adjusting the destination path inside the temp dir to match the relative dir used for the source (of the golden files), no conflict occurs when moving them to/from the temp dir.

Fixes #30 