### PR TITLE
Add instructions to migrate from v1 to v2 with Comby

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,37 @@ Finally, please note the renaming of functions before and after:
 * Inline tests: `autogold.Want` -> `autogold.Expect`
 * File tests: `autogold.Equal` -> `autogold.ExpectFile`
 
+##### Automating the migration with Comby
+
+The API changes from v1 to v2 are small and the following [Comby](https://comby.dev) configuration file can be used to migrate your codebase automatically: 
+
+```
+# autogold.comby.toml
+[update-imports]
+
+match="\"github.com/hexops/autogold\""
+rewrite="\"github.com/hexops/autogold/v2\""
+
+[update-api-want]
+
+match="autogold.Want(:[desc], :[v])"
+rewrite="autogold.Expect(:[v])"
+
+[update-api-equal]
+
+match="autogold.Equal(:[v])"
+rewrite="autogold.ExpectFile(:[v])"
+```
+
+Assuming Comby is available on your system, you can run the following command to apply the changes: 
+
+```
+$ go get -u github.com/hexops/autogold/v2
+$ comby -config autogold.comby.toml -matcher .go -exclude-dir vendor,node_modules -in-place
+$ go mod tidy
+$ git diff # show the changes applied by comby
+```
+
 #### v1.3.1
 
 * Improved Go code formatting (updated valast and gofumpt versions)

--- a/README.md
+++ b/README.md
@@ -172,7 +172,10 @@ Finally, please note the renaming of functions before and after:
 
 ##### Automating the migration with Comby
 
-The API changes from v1 to v2 are small and the following [Comby](https://comby.dev) configuration file can be used to migrate your codebase automatically: 
+You can automatically migrate from v1 to v2 using the following [Comby](https://comby.dev) configuration:
+
+<details>
+<summary>autogold.comby.toml</summary>
 
 ```
 # autogold.comby.toml
@@ -200,6 +203,8 @@ $ comby -config autogold.comby.toml -matcher .go -exclude-dir vendor,node_module
 $ go mod tidy
 $ git diff # show the changes applied by comby
 ```
+
+</details>
 
 #### v1.3.1
 


### PR DESCRIPTION
As I [ran a migration from v1 to v2 on our codebase](https://github.com/sourcegraph/sourcegraph/pull/47891) and used a Comby config file to do so, I thought it might be useful to provide it in the README for others to use. 

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.