### PR TITLE
allow usage together with other golden packages

### DIFF
--- a/autogold.go
+++ b/autogold.go
@@ -16,7 +16,6 @@ import (
 )
 
 var (
-	// update is defined below, in init()
 	clean        = flag.Bool("clean", false, "remove unused .golden files (slightly slower)")
 	failOnUpdate = flag.Bool("fail-on-update", false, "If a .golden file is updated, fail the test")
 

--- a/autogold.go
+++ b/autogold.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	update       = flag.Bool("update", false, "update .golden files, leaving unused)")
+	// update is defined below, in init()
 	clean        = flag.Bool("clean", false, "remove unused .golden files (slightly slower)")
 	failOnUpdate = flag.Bool("fail-on-update", false, "If a .golden file is updated, fail the test")
 
@@ -26,7 +26,17 @@ var (
 )
 
 func init() {
+	// For compatibility with other packages that also define an -update parameter, only define the
+	// flag if it's not already defined.
+	if updateFlag := flag.Lookup("update"); updateFlag == nil {
+		flag.Bool("update", false, "update .golden files, leaving unused)")
+	}
+
 	color.NoColor = false
+}
+
+func update() bool {
+	return flag.Lookup("update").Value.(flag.Getter).Get().(bool)
 }
 
 // ExpectFile checks if got is equal to the saved `testdata/<test name>.golden` test file. If it is
@@ -131,7 +141,7 @@ func ExpectFile(t *testing.T, got interface{}, opts ...Option) {
 		os.Remove(outFile)
 	}
 	if diff != "" {
-		if *update {
+		if update() {
 			grabLock()
 			if _, err := os.Stat(dir); os.IsNotExist(err) {
 				if err := os.MkdirAll(dir, 0o700); err != nil {
@@ -142,7 +152,7 @@ func ExpectFile(t *testing.T, got interface{}, opts ...Option) {
 				t.Fatal(err)
 			}
 		}
-		if *failOnUpdate || !*update {
+		if *failOnUpdate || !update() {
 			t.Log(fmt.Errorf("mismatch (-want +got):\n%s", colorDiff(diff)))
 			t.FailNow()
 		}

--- a/expect.go
+++ b/expect.go
@@ -156,7 +156,7 @@ func Expect(want interface{}) Value {
 			}
 
 			// Update the test file if so desired.
-			if *update {
+			if update() {
 				// Acquire a file-level lock to prevent concurrent mutations to the _test.go file
 				// by parallel tests (whether in-process, or not.)
 				start = time.Now()
@@ -181,7 +181,7 @@ func Expect(want interface{}) Value {
 					t.Fatal(fmt.Errorf("autogold: %v", err))
 				}
 			}
-			if *failOnUpdate || !*update {
+			if *failOnUpdate || !update() {
 				writeProfile()
 				t.Log(fmt.Errorf("mismatch (-want +got):\n%s", colorDiff(diff)))
 				t.FailNow()


### PR DESCRIPTION
Other packages can also define an -update flag. In general we can't be compatible with every possible conflicting flag, but for this specific flag we assume that it's a boolean flag with the same meaning as ours.

My motivation for this change is usage of autogold along with gotest.tools/v3/assert, which among other things, has its own golden tests functionality.

---

There's an open PR for `gotest.tools/v3/assert` to do the same - see https://github.com/gotestyourself/gotest.tools/pull/271.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.