### PR TITLE
find correct import path for _test packages

### DIFF
--- a/expect_test.go
+++ b/expect_test.go
@@ -178,7 +178,7 @@ func Test_replaceExpect_multiple(t *testing.T) {
 	ExpectFile(t, Raw(got))
 }
 func Test_getPackageNameAndPath(t *testing.T) {
-	pkgName, pkgPath, err := getPackageNameAndPath(".")
+	pkgName, pkgPath, err := getPackageNameAndPath(".", "expect_test.go")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,7 +191,7 @@ func Test_getPackageNameAndPath(t *testing.T) {
 }
 
 func Test_getPackageNameAndPath_subdir(t *testing.T) {
-	pkgName, pkgPath, err := getPackageNameAndPath("./internal/test")
+	pkgName, pkgPath, err := getPackageNameAndPath("./internal/test", "test.go")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,6 +203,23 @@ func Test_getPackageNameAndPath_subdir(t *testing.T) {
 		t.Fatal("\ngot:\n", pkgName, "\nwant:\n", want)
 	}
 	if want := "github.com/hexops/autogold/v2/internal/test"; pkgPath != want {
+		t.Fatal("\ngot:\n", pkgPath, "\nwant:\n", want)
+	}
+}
+
+func Test_getPackageNameAndPath_subdir_blackbox(t *testing.T) {
+	pkgName, pkgPath, err := getPackageNameAndPath("./internal/test", "blackbox_test.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "test_test"
+	if isBazel() {
+		want = "autogold"
+	}
+	if pkgName != want {
+		t.Fatal("\ngot:\n", pkgName, "\nwant:\n", want)
+	}
+	if want := "github.com/hexops/autogold/v2/internal/test_test"; pkgPath != want {
 		t.Fatal("\ngot:\n", pkgPath, "\nwant:\n", want)
 	}
 }
@@ -240,12 +257,12 @@ func testEqualSubtestSameNames(t *testing.T) {
 func Benchmark_getPackageNameAndPath_cached(b *testing.B) {
 	// Wipe the cache, as it was populated by other tests.
 	getPackageNameAndPathCacheMu.Lock()
-	getPackageNameAndPathCache = map[string][2]string{}
+	getPackageNameAndPathCache = map[[2]string][2]string{}
 	getPackageNameAndPathCacheMu.Unlock()
 
 	start := time.Now()
 	for n := 0; n < b.N; n++ {
-		_, _, err := getPackageNameAndPath("./autogold/internal/test")
+		_, _, err := getPackageNameAndPath("./autogold/internal/test", "test.go")
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/test/blackbox_test.go
+++ b/internal/test/blackbox_test.go
@@ -1,0 +1,4 @@
+package test_test
+
+// This import is here so that `go test ./... -update` in the repository root doesn't fail.
+import _ "github.com/hexops/autogold/v2"


### PR DESCRIPTION
When using _test packages that used types from the corresponding non-_test package before this commit, autogold would pass the wrong package name to valast and the replacements would be in the form Type{} instead of pkg.Type{}.

We now look for the package containing the tested file rather than using the non-test package in the same directory.

---

Fixes https://github.com/hexops/autogold/issues/25.

I included a test for `getPackageNameAndPath`, but there's no test using actual files. Let me know if I should add one - it'd require two files and all the current tests only need one, so I haven't tried yet.

I have tested this on my project and it does work.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.