### PR TITLE
lint: fix golangci-lint issues

### DIFF
--- a/autogold.go
+++ b/autogold.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -124,7 +123,7 @@ func ExpectFile(t *testing.T, got interface{}, opts ...Option) {
 		unlock() // don't hold the lock while we perform IO, diffing, etc. below.
 	}
 
-	want, err := ioutil.ReadFile(outFile)
+	want, err := os.ReadFile(outFile)
 	if err != nil && !os.IsNotExist(err) {
 		t.Fatal(err)
 	}
@@ -137,7 +136,7 @@ func ExpectFile(t *testing.T, got interface{}, opts ...Option) {
 	isEmptyFile := isRaw && gotString == ""
 	if isEmptyFile && shouldCleanup() {
 		grabLock()
-		os.Remove(outFile)
+		_ = os.Remove(outFile)
 	}
 	if diff != "" {
 		if update() {
@@ -147,7 +146,7 @@ func ExpectFile(t *testing.T, got interface{}, opts ...Option) {
 					t.Fatal(err)
 				}
 			}
-			if err := ioutil.WriteFile(outFile, []byte(gotString), 0o666); err != nil {
+			if err := os.WriteFile(outFile, []byte(gotString), 0o666); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/expect.go
+++ b/expect.go
@@ -6,7 +6,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -59,7 +58,6 @@ func getPackageNameAndPath(dir, file string) (name, path string, err error) {
 	pkgs, err := packages.Load(&packages.Config{Mode: packages.NeedName | packages.NeedFiles, Tests: true}, dir)
 	if err != nil {
 		return "", "", err
-
 	}
 
 	var testPkg *packages.Package
@@ -291,7 +289,7 @@ func replaceExpect(t *testing.T, testFilePath, testName string, line int, replac
 		}
 	}()
 
-	testFileSrc, err := ioutil.ReadFile(testFilePath)
+	testFileSrc, err := os.ReadFile(testFilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +350,7 @@ func replaceExpect(t *testing.T, testFilePath, testName string, line int, replac
 		if err != nil {
 			return nil, err
 		}
-		if err := ioutil.WriteFile(testFilePath, []byte(newFile), info.Mode()); err != nil {
+		if err := os.WriteFile(testFilePath, []byte(newFile), info.Mode()); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
The following issues were fixed:

```
autogold.go:140:12: Error return value of `os.Remove` is not checked (errcheck)
autogold.go:7:2: SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package [io] or package [os], and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
expect.go:9:2: SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package [io] or package [os], and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
```

---

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.
