### PR TITLE
ci: Test against current and previous Go versions

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -4,6 +4,10 @@ on:
   - pull_request
 jobs:
   test:
+    name: Test (Go ${{ matrix.go-version }})
+    strategy:
+      matrix:
+        go-version: [stable, oldstable]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -11,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1
+          go-version: ${{ matrix.go-version }}
       - run: go test ./...
       # Testing with -update enabled isn't intended to update the golden files, but to help validate that there aren't
       # problems when updating is enabled, race conditions in the update process etc


### PR DESCRIPTION
Go's support policy is to support the two most recent minor releases:
e.g., with the release of Go 1.25, the supported versions are
1.24 and 1.25. Most libraries follow the same support policy.

While the support policy for autogold is not necessarily written down,
given that 1.24 and 1.25 (current stable and oldstable) work fine,
test against both in CI until there's a reason not to.

Note:
The "stable" and "olstable" aliases require setup-go v3 or later.

---

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.
