### PR TITLE
fix(README): Point Go reference badge to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # autogold - automatically update your Go tests <a href="https://hexops.com"><img align="right" alt="Hexops logo" src="https://raw.githubusercontent.com/hexops/media/master/readme.svg"></img></a>
 
-<a href="https://pkg.go.dev/github.com/hexops/autogold"><img src="https://pkg.go.dev/badge/badge/github.com/hexops/autogold.svg" alt="Go Reference" align="right"></a>
-  
+<a href="https://pkg.go.dev/github.com/hexops/autogold/v2"><img src="https://pkg.go.dev/badge/badge/github.com/hexops/autogold/v2.svg" alt="Go Reference" align="right"></a>
+
 [![Go CI](https://github.com/hexops/autogold/workflows/Go%20CI/badge.svg)](https://github.com/hexops/autogold/actions) [![codecov](https://codecov.io/gh/hexops/autogold/branch/main/graph/badge.svg)](https://codecov.io/gh/hexops/autogold) [![Go Report Card](https://goreportcard.com/badge/github.com/hexops/autogold)](https://goreportcard.com/report/github.com/hexops/autogold)
 
 autogold makes `go test -update` automatically update your Go tests (golden files and Go values in e.g. `foo_test.go`).


### PR DESCRIPTION
The README godoc badge points to the v1 of the library.
Point to v2 instead.

---

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.
