### PR TITLE
all: use modern Go syntax (e.g. any instead of interface{})

### DIFF
--- a/autogold.go
+++ b/autogold.go
@@ -46,7 +46,7 @@ func update() bool {
 //
 // If the input value is of type Raw, its contents will be directly used instead of the value being
 // formatted as a Go literal.
-func ExpectFile(t *testing.T, got interface{}, opts ...Option) {
+func ExpectFile(t *testing.T, got any, opts ...Option) {
 	dir := testdataDir(opts)
 	fileName := testName(t, opts)
 	outFile := filepath.Join(dir, fileName+".golden")

--- a/diff.go
+++ b/diff.go
@@ -17,7 +17,7 @@ func diff(got, want string, opts []Option) string {
 // Raw denotes a raw string.
 type Raw string
 
-func stringify(v interface{}, opts []Option) string {
+func stringify(v any, opts []Option) string {
 	var (
 		allowRaw, trailingNewline bool
 		valastOpt                 = &valast.Options{}

--- a/expect.go
+++ b/expect.go
@@ -25,15 +25,15 @@ import (
 // Value describes a desired value for a Go test, see Expect for more information.
 type Value interface {
 	// Equal checks if `got` matches the desired test value, invoking t.Fatal otherwise.
-	Equal(t *testing.T, got interface{}, opts ...Option)
+	Equal(t *testing.T, got any, opts ...Option)
 }
 
 type value struct {
 	line  int
-	equal func(t *testing.T, got interface{}, opts ...Option)
+	equal func(t *testing.T, got any, opts ...Option)
 }
 
-func (v value) Equal(t *testing.T, got interface{}, opts ...Option) {
+func (v value) Equal(t *testing.T, got any, opts ...Option) {
 	t.Helper()
 	v.equal(t, got, opts...)
 }
@@ -90,11 +90,11 @@ find:
 // When `-update` is specified, autogold will find and replace in the test file by looking for an
 // invocation of `autogold.Expect(...)` at the same line as the callstack indicates for this function
 // call, rewriting the `want` value parameter for you.
-func Expect(want interface{}) Value {
+func Expect(want any) Value {
 	_, _, line, _ := runtime.Caller(1)
 	return value{
 		line: line,
-		equal: func(t *testing.T, got interface{}, opts ...Option) {
+		equal: func(t *testing.T, got any, opts ...Option) {
 			t.Helper()
 			var (
 				profGetPackageNameAndPath time.Duration

--- a/expect_test.go
+++ b/expect_test.go
@@ -163,7 +163,6 @@ func Test_replaceExpect_multiple(t *testing.T) {
 	}
 
 	for _, r := range replacements {
-		r := r
 		_, err := replaceExpect(t, tmpFile, r.testName, r.line, r.replacement, true)
 		if err != nil {
 			t.Log("\ngot:\n", err, "\nwant:\n", err)
@@ -244,7 +243,6 @@ func testEqualSubtestSameNames(t *testing.T) {
 	}
 
 	for _, name := range testTable {
-		name := name
 
 		t.Run(name, func(t *testing.T) {
 			// Subtests are intentionally not run in parallel, as that makes this issue more easily reproducible

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -23,7 +23,6 @@ func testParallel(t *testing.T, prefix string) {
 	}
 
 	for _, name := range testTable {
-		name := name
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
This change was generated by running:

```
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...
```

Two things are changed:

- All `interface{}` types are changed to `any`.
  This has been available since Go 1.18.
- Stops capturing loop variables for closures inside loops.
  This has been unnecessary since Go 1.22.
  (https://go.dev/blog/loopvar-preview)

---

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.
